### PR TITLE
Revamped CMake; suppressed warnings; bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,113 @@
 PROJECT( sbml2matlab )
 CMAKE_MINIMUM_REQUIRED( VERSION 2.8 )
 
+# Set build type default.
+set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+    "Choose the build type. The options are: None (CMAKE_CXX_FLAGS or
+     CMAKE_C_FLAGS are used), Debug, Release, RelWithDebInfo, MinSizeRel.")
+if("${CMAKE_BUILD_TYPE}" STREQUAL "")
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+  "Choose the build type. The options are: None (CMAKE_CXX_FLAGS or
+  CMAKE_C_FLAGS are used), Debug, Release, RelWithDebInfo, MinSizeRel." FORCE)
+endif()
+
+set(EXTRA_LIBS "" CACHE STRING "Semicolon separatred list of additional libraries to link against." )
+
+OPTION(WITH_LIBSBML_EXPAT  "Set if libsbml was compiled with a separate expat library." OFF)
+OPTION(WITH_LIBSBML_LIBXML "Set if libsbml was compiled with a separate libxml library." OFF)
+OPTION(WITH_LIBSBML_XERCES "Set if libsbml was compiled with a separate xerces library." OFF)
+OPTION(WITH_LIBSBML_COMPRESSION "Set if libsbml was compiled with separate zdll and bzip libraries." OFF)
+OPTION(LIBSBML_STATIC "Whether to use the static libsbml library" ON)
+
+
+if(WITH_LIBSBML_EXPAT)
+    find_library(EXPAT_LIBRARY 
+        NAMES libexpat.lib libexpat.so libexpat.dylib libexpat
+	PATHS /usr/lib /usr/local/lib 
+              ${CMAKE_SOURCE_DIR} 
+              ${CMAKE_SOURCE_DIR}/dependencies/lib
+              ${LIBSBML_INCLUDE_DIR}/../lib
+        )
+    set(SBML2MATLAB_LIBS ${SBML2MATLAB_LIBS} ${EXPAT_LIBRARY} )
+endif()
+
+if(WITH_LIBSBML_LIBXML)
+    find_library(LIBXML_LIBRARY 
+        NAMES libxml2.lib libxml2.so libxml2.dylib libxml2
+	PATHS /usr/lib /usr/local/lib 
+              ${CMAKE_SOURCE_DIR} 
+              ${CMAKE_SOURCE_DIR}/dependencies/lib
+              ${LIBSBML_INCLUDE_DIR}/../lib
+        )
+    set(SBML2MATLAB_LIBS ${SBML2MATLAB_LIBS} ${LIBXML_LIBRARY} )
+
+    find_library(ICONV_LIBRARY 
+        NAMES iconv.lib iconv.so iconv.dylib iconv
+	PATHS /usr/lib /usr/local/lib 
+              ${CMAKE_SOURCE_DIR} 
+              ${CMAKE_SOURCE_DIR}/dependencies/lib
+              ${LIBSBML_INCLUDE_DIR}/../lib
+        )
+    set(SBML2MATLAB_LIBS ${SBML2MATLAB_LIBS} ${ICONV_LIBRARY} )
+endif()
+
+if(WITH_LIBSBML_XERCES)
+    find_library(XERCES_LIBRARY 
+        NAMES xerces-c_static_3.lib xerces-c_static_3.so xerces-c_static_3.dylib xerces-c_static_3
+	PATHS /usr/lib /usr/local/lib 
+              ${CMAKE_SOURCE_DIR} 
+              ${CMAKE_SOURCE_DIR}/dependencies/lib
+              ${LIBSBML_INCLUDE_DIR}/../lib
+        )
+    set(SBML2MATLAB_LIBS ${SBML2MATLAB_LIBS} ${XERCES_LIBRARY} )
+endif()
+
+if(WITH_LIBSBML_COMPRESSION)
+    find_library(ZDLL_LIBRARY 
+        NAMES zdll.lib zdll.so zdll.dylib zdll
+	PATHS /usr/lib /usr/local/lib 
+              ${CMAKE_SOURCE_DIR} 
+              ${CMAKE_SOURCE_DIR}/dependencies/lib
+              ${LIBSBML_INCLUDE_DIR}/../lib
+        )
+    set(SBML2MATLAB_LIBS ${SBML2MATLAB_LIBS} ${ZDLL_LIBRARY} )
+
+    find_library(BZIP_LIBRARY 
+        NAMES bzip2.lib bzip2.so bzip2.dylib bzip2
+	PATHS /usr/lib /usr/local/lib 
+              ${CMAKE_SOURCE_DIR} 
+              ${CMAKE_SOURCE_DIR}/dependencies/lib
+              ${LIBSBML_INCLUDE_DIR}/../lib
+        )
+    set(SBML2MATLAB_LIBS ${SBML2MATLAB_LIBS} ${BZIP_LIBRARY} )
+endif()
+
+set(SBML2MATLAB_LIBS ${SBML2MATLAB_LIBS} ${EXTRA_LIBS} )
+
+if(WIN32 AND NOT UNIX)
+    #Add this flag to suppress 'sprintf' vs. 'sprintf_s' and 'strcpy' vs. 'strcpy_s' warnings in VS.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS")
+    #We throw C++ exceptions from our 'C' functions; change the Exception Handler (EH) flag
+    string(REGEX
+       REPLACE
+       "/EHsc"
+       "/EHs"
+       CMAKE_CXX_FLAGS
+       "${CMAKE_CXX_FLAGS}"
+    )
+
+    string(REGEX
+       REPLACE
+       "/EHc"
+       "/EHs"
+       CMAKE_CXX_FLAGS
+       "${CMAKE_CXX_FLAGS}"
+    )
+
+# The following line can make the modified version show up in CMake, but weird things happen with multiple compiles, if so.
+#    set( CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} CACHE STRING "Flags used by the compiler during all build types (Forced version)." FORCE )
+endif()
+
 # dependencies
 # it will expect a CMakeLists.txt in each folder
 ADD_SUBDIRECTORY(NOM)
@@ -9,7 +116,7 @@ ADD_SUBDIRECTORY(NOM)
 # dependency headers
 INCLUDE_DIRECTORIES(
     ${PROJECT_SOURCE_DIR}/NOM
-    ${LIBSBML_INCLUDE}
+    ${LIBSBML_INCLUDE_DIR}
 )
 
 link_directories(${LIBSBML_LIB})
@@ -53,7 +160,7 @@ SET(CPACK_PACKAGE_INSTALL_DIRECTORY "sbml2matlab-${CPACK_PACKAGE_VERSION_MAJOR}.
 
 IF(WIN32 AND NOT UNIX)
   # There is a bug in NSI that does not handle full unix paths properly. Make
-  # sure there is at least one set of four (4) backlasshes.
+  # sure there is at least one set of four (4) backslashes.
   # SET(CPACK_PACKAGE_ICON "${CMake_SOURCE_DIR}/Utilities/Release\\\\InstallIcon.bmp")
   SET(CPACK_NSIS_INSTALLED_ICON_NAME "sbml2matlab.exe")
   SET(CPACK_NSIS_DISPLAY_NAME "${CPACK_PACKAGE_INSTALL_DIRECTORY}")

--- a/NOM/CMakeLists.txt
+++ b/NOM/CMakeLists.txt
@@ -5,27 +5,60 @@ CMAKE_MINIMUM_REQUIRED( VERSION 2.8 )
 # define target
 SET (TARGET NOM)
 
+####################################################################
+#
+# Locate libsbml
+#
 
-# define sources
+find_path(LIBSBML_INCLUDE_DIR "The 'include' directory for libsbml"
+        NAMES sbml/SBMLTypes.h
+        PATHS /usr/include /usr/local/include 
+              ${CMAKE_SOURCE_DIR}/include 
+              ${CMAKE_SOURCE_DIR}/dependencies/include
+        )
 
-SET (LIBSBML_INCLUDE CACHE PATH "Full Path to LIBSBML Include Directory")
-SET (LIBSBML_LIB CACHE PATH "Full Path to LIBSBML Import Libraries")
-SET (LIBSBML_BIN CACHE PATH "Full Path to LIBSBML Binaries")
+if(LIBSBML_STATIC)
+    find_library(LIBSBML_STATIC_LIBRARY 
+        NAMES libsbml-static.lib libsbml-static.so libsbml-static.dylib libsbml-static
+        PATHS /usr/lib /usr/local/lib 
+              ${CMAKE_SOURCE_DIR} 
+              ${CMAKE_SOURCE_DIR}/dependencies/lib
+        )
+    set(SBML2MATLAB_LIBS ${SBML2MATLAB_LIBS} ${LIBSBML_STATIC_LIBRARY} )
+else()
+    find_library(LIBSBML_LIBRARY 
+        NAMES libsbml.lib libsbml.so libsbml.dylib libsbml
+        PATHS /usr/lib /usr/local/lib 
+              ${CMAKE_SOURCE_DIR} 
+              ${CMAKE_SOURCE_DIR}/dependencies/lib
+        )
+   set(SBML2MATLAB_LIBS ${SBML2MATLAB_LIBS} ${LIBSBML_LIBRARY} )
+endif()
 
+if(WIN32)
+  #Find the libsbml dll so we can install it with our program.
+  find_path(LIBSBML_BIN_DIR
+        NAMES libsbml.dll
+        PATHS /usr/bin /usr/local/bin
+              ${LIBSBML_INCLUDE_DIR}/../bin
+              ${CMAKE_SOURCE_DIR}/ 
+              ${CMAKE_SOURCE_DIR}/dependencies/libsbml/bin
+              ${CMAKE_SOURCE_DIR}/../libsbml-5/release/bin/
+        )
+        set(LIBSBML_DLL ${LIBSBML_BIN_DIR}/libsbml.dll)
+        install(FILES   ${LIBSBML_DLL} DESTINATION .)
+endif()
 
-
-# dependencies
-# it will expect a CMakeLists.txt in each folder
-# ADD_SUBDIRECTORY( sbml )
 
 # dependency headers
 INCLUDE_DIRECTORIES(
-    ${LIBSBML_INCLUDE}
+    ${INCLUDE_DIRECTORIES}
+    ${LIBSBML_INCLUDE_DIR}
 )
 
 # have linker point to libsbml
-#link_directories(${LIBSBML_LIBRARY})
-link_directories(${LIBSBML_LIB})
+link_directories(${LIBSBML_LIBRARY})
+#link_directories(${LIBSBML_LIB})
 
 # source files
 FILE( GLOB NOM_SOURCE_FILES
@@ -42,81 +75,31 @@ ADD_LIBRARY( ${TARGET}
 
 
 
-# set_property(TARGET ${TARGET}-static 
-                # PROPERTY    COMPILE_DEFINITIONS 
-                            # LIBSBML_STATIC
-# ) 
+TARGET_LINK_LIBRARIES(${TARGET} ${SBML2MATLAB_LIBS} )
 
+#We can afford to look for everything here, since anything not found will simply be ignored.
 if (WIN32)
-	# link to dependencies
-	
-	TARGET_LINK_LIBRARIES( ${TARGET}
-		${LIBSBML_LIB}/libcheck.lib
-		${LIBSBML_LIB}/libexpat.lib
-		${LIBSBML_LIB}/iconv.lib
-		${LIBSBML_LIB}/libxml2.lib
-		${LIBSBML_LIB}/libsbml-static.lib
-		${LIBSBML_LIB}/xerces-c_static_3.lib
-		${LIBSBML_LIB}/xerces-c_static_3D.lib
-		${LIBSBML_LIB}/zdll.lib
-		${LIBSBML_LIB}/bzip2.lib
-
-	)
-	set_property(TARGET ${TARGET} 
-                PROPERTY    COMPILE_DEFINITIONS 
-                            LIBSBML_STATIC
-							LIBLAX_STATIC
-                            ) 
-	# gathering libsbml/NOM dependencies
-	file(GLOB NOM_DEPENDENCIES 
-	# "${LIBSBML_BIN}/*.dll
-		${LIBSBML_BIN}/bzip2.dll
-		${LIBSBML_BIN}/iconv.dll
-		${LIBSBML_BIN}/libcheck.dll
-		${LIBSBML_BIN}/libexpat.dll
-		${LIBSBML_BIN}/libxml2.dll
-		${LIBSBML_BIN}/msvcp100.dll
-		${LIBSBML_BIN}/msvcr100.dll
-		${LIBSBML_BIN}/MSVCRT.dll
-		${LIBSBML_BIN}/xerces-c_3_1.dll
-		${LIBSBML_BIN}/zlib1.dll
-	)
-	# build static library
-	ADD_LIBRARY( ${TARGET}-static
-		STATIC
-		${NOM_SOURCE_FILES}
-	)
-	target_link_libraries(${TARGET}-static
-		${LIBSBML_LIB}/libsbml-static.lib
-	)
-elseif (APPLE)	
-	TARGET_LINK_LIBRARIES( NOM
-		${LIBSBML_LIB}/libsbml.dylib
-	)
-else ()
-	# link to dependencies
-	TARGET_LINK_LIBRARIES( NOM
-		${LIBSBML_LIB}/libsbml.so
-	)
-	# Installing libsbml/NOM dependencies
-	# removed because it is generating broken links
-	#file(GLOB NOM_DEPENDENCIES "${LIBSBML_BIN}/libsbml.so" "${LIBSBML_BIN}/libxml2.so")
+    # gathering libsbml/NOM dependencies
+    file(GLOB NOM_DEPENDENCIES 
+        # "${LIBSBML_BIN}/*.dll
+        ${LIBSBML_BIN}/bzip2.dll
+        ${LIBSBML_BIN}/iconv.dll
+        ${LIBSBML_BIN}/libcheck.dll
+        ${LIBSBML_BIN}/libexpat.dll
+        ${LIBSBML_BIN}/libxml2.dll
+        ${LIBSBML_BIN}/msvcp100.dll
+        ${LIBSBML_BIN}/msvcr100.dll
+        ${LIBSBML_BIN}/MSVCRT.dll
+        ${LIBSBML_BIN}/xerces-c_3_1.dll
+        ${LIBSBML_BIN}/zlib1.dll
+    )
 endif ()
 
-
-
-# link to dependencies
-# TARGET_LINK_LIBRARIES( NOM
-    # ${LIBSBML_LIB}/libsbml.lib
-    # ${LIBSBML_LIB}/bzip2.lib
-    # ${LIBSBML_LIB}/iconv.lib
-    # ${LIBSBML_LIB}/libcheck.lib
-    # ${LIBSBML_LIB}/libexpat.lib
-    # ${LIBSBML_LIB}/libxml2.lib
-    # ${LIBSBML_LIB}/xerces-c_3.lib
-    # ${LIBSBML_LIB}/xerces-c_3D.lib
-    # ${LIBSBML_LIB}/zdll.lib
-# )
+# build static library
+ADD_LIBRARY( ${TARGET}-static
+    STATIC
+    ${NOM_SOURCE_FILES}
+)
 
 # install NOM
 install(TARGETS NOM LIBRARY DESTINATION . RUNTIME DESTINATION . ARCHIVE DESTINATION .)

--- a/NOM/NOM.h
+++ b/NOM/NOM.h
@@ -70,7 +70,7 @@ extern "C" {
 	*
 	* @return char* to the error message
 	*/
-	DLL_EXPORT char *getError ();
+	DLL_EXPORT const char *getError ();
 
 
 	/** @brief Load SBML into the NOM. 
@@ -526,7 +526,7 @@ extern "C" {
 	* @param[in] nVersion is the version of output SBML
 	* @return -1 if there has been an error
 	*/
-	DLL_EXPORT int convertSBML(char *inputModel, char **outputModel, int nLevel, int nVersion);
+	DLL_EXPORT int convertSBML(const char *inputModel, char **outputModel, int nLevel, int nVersion);
 
 }
 

--- a/sbml2matlab.cpp
+++ b/sbml2matlab.cpp
@@ -32,6 +32,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <clocale>
 #include <exception>
 
+#ifdef WIN32
+#ifndef CYGWIN
+#define strdup _strdup
+#endif
+#endif
+
 #define CONVERT_ANY(source,target)\
 		{\
 		std::stringstream oStream;\
@@ -58,12 +64,12 @@ typedef struct {
 	double value;
 } TNameValue;
 
-typedef struct TUserFuncInfo {
+typedef struct {
 	char *fnId;
 	int numArgs;
 	char **argList;
 	char *body;
-};
+} TUserFuncInfo;
 
 
 // Define a data structure to hold all information required
@@ -1662,9 +1668,9 @@ public:
 				}
 			}
 		}
-		for (int i = 0; i < rulesToConvert.size(); i++)
+		for (size_t i = 0; i < rulesToConvert.size(); i++)
 		{
-			for (int j = 0; j < paramsToConvert.size(); j++)
+			for (size_t j = 0; j < paramsToConvert.size(); j++)
 			{
 				stringReplace(rulesToConvert[i], paramsToConvert[j], convertParamsTo[j]);
 			}
@@ -2067,7 +2073,7 @@ DLL_EXPORT void freeMatlabString(char* matlabInput)
 	free(matlabInput);
 }
 
-DLL_EXPORT char *getNomErrors()
+DLL_EXPORT const char *getNomErrors()
 {
 	return getError();
 }

--- a/sbml2matlab.h
+++ b/sbml2matlab.h
@@ -61,7 +61,7 @@ extern "C"
 	*
 	* @return char* to the error message
 	*/
-	DLL_EXPORT char *getNomErrors();
+	DLL_EXPORT const char *getNomErrors();
 
 	/** @brief Returns number of errors in SBML model
 	*


### PR DESCRIPTION
Revamp CMake build system to be more flexible, and (hopefully) work on more OSes.  Also found ways to get rid of a variety of warnings, by changing flags (such as the exception handling flag), and by fixing the code (addMissingModifiersInternal in particular looked like it was set up to crash, as it was using uninitialized pointers).  Elsewhere, pointers to local variables were being returned, which almost certainly would result in memory problems.
